### PR TITLE
Add WORKFLOW_REPOS project

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -28,3 +28,24 @@ PAM_MUJOCO:
 BALL_TRACKING:
     parent_projects: ['AMENT']
     repos: ['tennicam_proto','tennicam','mpi_cmake_modules']
+
+# List of repositories to which common GitHub workflows should be added (e.g.
+# for style checks on pull requests).
+WORKFLOW_REPOS:
+    repos: [
+        'context',
+        'frequency_monitoring',
+        'github_workflow_manager',
+        'json_helper',
+        'mujoco_interface',
+        'o80',
+        'o80_example',
+        'o80_pam',
+        'pam_interface',
+        'pam_models',
+        'pam_mujoco',
+        'serialization_utils',
+        'signal_handler',
+        'synchronizer',
+        'tennicam_client',
+    ]

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -121,3 +121,8 @@ tennicam:
 tennicam_client:
    path: src
    origin: isr
+
+github_workflow_manager:
+   path: src
+   origin: isr
+   branch: main


### PR DESCRIPTION

## Description

This project lists all repositories which should receive the common GitHub workflows.
Having this as a dedicated treep project makes it easier to run the script that copies the workflows to all of them.

For now this are all isr/mpi-is repos of the PAM_MUJOCO project plus the github_workflow_manager.



## How I Tested

By running `treep --clone WORKFLOW_REPOS`