### PR TITLE
Add HTTPS origins

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,8 +1,12 @@
 origin_prefixes:
     isr: 'git@github.com:intelligent-soft-robots/'
+    https-isr: 'https://github.com/intelligent-soft-robots/'
     mim: 'git@github.com:machines-in-motion/'
+    https-mim: 'https://github.com/machines-in-motion/'
     odri: 'git@github.com:open-dynamic-robot-initiative/'
+    https-odri: 'https://github.com/open-dynamic-robot-initiative/'
     mpi-is: 'git@github.com:MPI-IS/'
+    https-mpi-is: 'https://github.com/MPI-IS/'
     robotics: 'git@gitlab.is.tuebingen.mpg.de:robotics/'
     https-pybind: 'https://github.com/pybind/'
     https-ament: 'https://github.com/ament/'

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1,6 +1,6 @@
 googletest:
     path: src
-    origin: git@github.com:google/googletest.git
+    origin: https://github.com/google/googletest.git
     branch: main
 
 ament_cmake:


### PR DESCRIPTION
## Description

- Add HTTPS origins for GitHub organisations
- Change the origin of googletest to use HTTPS


## How I Tested

Comparing the outcome of `treep --clone PAM_MUJOCO` and `treep --clone-https PAM_MUJOCO`.