### PR TITLE
Add ament_googletest

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1,5 +1,5 @@
 AMENT:
-    repos: ['ament_cmake','ament_package']
+    repos: ['ament_cmake', 'ament_package', 'ament_googletest']
 
 CORE:
     parent_projects: ['AMENT']

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -7,10 +7,15 @@ ament_cmake:
    path: src
    origin: https-ament
    branch: eloquent
-   
+
 ament_package:
    path: src
    origin: https-ament
+   branch: eloquent
+
+ament_googletest:
+   path: src
+   origin: https://github.com/ament/googletest.git
    branch: eloquent
 
 mujoco_interface:


### PR DESCRIPTION
This is more or less a duplicate of the original googletest repo (already included in the config) but with some modifications to be used by ament (it provides gtest and gmock as "vendor" packages").

It's a bit stupid as it is duplicating the library in the workspace but unfortunately we need this for 'ament_cmake_gmock' to work while we also still need to keep the vanilla googletest for packages that don't use ament.  At least the presence of both in the same workspace does not seem to cause any trouble.

Note that the repo is actually just called "googletest" but I renamed it here to "ament_googletest" to avoid the name collision with the existing "googletest".