### PR TITLE
Upgrade pybind11 to 2.10.2

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -49,7 +49,7 @@ time_series:
 pybind11:
     path: src
     origin: https-pybind
-    tag: v2.5.0
+    tag: v2.10.2
 
 mpi_cmake_modules:
     path: src


### PR DESCRIPTION
## Description

I had some weird pybind11-related issue related to `std::filesystem` which could be resolved by updating to the latest version.

Edit: I think automatic bindings for `std::filesystem::path` were simply not yet supported by the older version.

## How I Tested

Build the PAM_MUJOCO workspace and ran tests.  A test of o80_pam was failing but if I remember correctly this was already the case before, so likely not related to the change.